### PR TITLE
Use existing events manager if one is already defined

### DIFF
--- a/src/Phalcon/Auth/Middleware/Micro.php
+++ b/src/Phalcon/Auth/Middleware/Micro.php
@@ -134,7 +134,7 @@ class Micro
 	{
 		$diName = self::$diName;
 
-		$eventsManager = $this-app->getEventsManager() ?? new EventsManager();
+		$eventsManager = $this->app->getEventsManager() ?? new EventsManager();
 		$eventsManager->attach(
 		    "micro:beforeExecuteRoute",
 		    function (Event $event, $app) use($diName) {

--- a/src/Phalcon/Auth/Middleware/Micro.php
+++ b/src/Phalcon/Auth/Middleware/Micro.php
@@ -134,7 +134,7 @@ class Micro
 	{
 		$diName = self::$diName;
 
-		$eventsManager = new EventsManager();
+		$eventsManager = $this-app->getEventsManager() ?? new EventsManager();
 		$eventsManager->attach(
 		    "micro:beforeExecuteRoute",
 		    function (Event $event, $app) use($diName) {


### PR DESCRIPTION
An events manager that I already had in my app was being overridden. Please merge!