### PR TITLE
Support to change authentication algorithm

### DIFF
--- a/src/Phalcon/Auth/Middleware/Micro.php
+++ b/src/Phalcon/Auth/Middleware/Micro.php
@@ -50,7 +50,7 @@ class Micro
      * @param array|config $config
      *
      */
-	public function __construct(MvcMicro $app, array $config=NULL)
+	public function __construct(MvcMicro $app, array $config=NULL, Auth $auth=NULL)
 	{
 		/**
 		 * example of config:
@@ -92,7 +92,10 @@ class Micro
 		$this->payload = (array) $this->config['payload'] ?? [];
 
 		$this->app = $app;
-		$this->auth = new Auth;
+		$this->auth = $auth;
+		if($auth === NULL) {
+		    $this->auth = new Auth;
+		}
 
 		$this->setDi();
 		$this->setEventChecker();


### PR DESCRIPTION
Since the `Dmkit\Phalcon\Auth\Auth` object instantiation is currently buried in the  `Dmkit\Phalcon\Auth\Middleware\Micro` constructor, there's no way to change the algorithm, and hence the library is useless if we want to use a public / private keypair as illustrated by the [php-jwt project](https://github.com/firebase/php-jwt#example-with-rs256-openssl).

This is a trivial backwards-compatible patch which allows you to pass in an `Auth` instance, so you can change the algorithm.